### PR TITLE
Update(security): Matchers 권한수정 #7

### DIFF
--- a/src/main/java/project_1st_team03/dashboard/global/config/security/SecurityConfig.java
+++ b/src/main/java/project_1st_team03/dashboard/global/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package project_1st_team03.dashboard.global.config.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -45,7 +46,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/login").permitAll()
                                 .requestMatchers("/posts/search/**").permitAll()
                                 .requestMatchers("/posts/**").permitAll()
-                                .requestMatchers("/comments/**").permitAll()
+                                .requestMatchers(HttpMethod.GET,"/api/comments/**").permitAll()
                                 .anyRequest().authenticated() // 그 외의 요청은 인증
                 )
                 .exceptionHandling(


### PR DESCRIPTION


## 관련 이슈

#7 

## 작업 내용
시큐리티가 적용되면 모든 요청에 인증이 요구된다.
댓글은 회원이 아니어도 읽을 수 있지만
다른 요청은 인증이 요구되도록 수정하였다.
